### PR TITLE
[Resolve deprecation] Add log library

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Firstly make sure to build the exporter binary using `make`.
 | `--server-address` | The address to host the server on | 127.0.0.1 |
 | `--server-port` | The port to host the server on | 9091 |
 | `--per-node-refresh` | How frequently to collect `per_node_bucket_stats` in seconds | 5 |
+| `--log-level` | The log level of the exporter | warn |
+| `--log-json` | If true logs will be JSON formated | true |
 
 ### Docker
 

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,9 @@ module github.com/couchbase/couchbase-exporter
 go 1.12
 
 require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
+	github.com/go-kit/kit v0.8.0
 	github.com/go-logr/zapr v0.1.1 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
-	github.com/prometheus/common v0.6.0
 	sigs.k8s.io/controller-runtime v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,11 +18,7 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
-github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -61,8 +57,10 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
@@ -103,6 +101,7 @@ github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
@@ -156,8 +155,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/main.go
+++ b/main.go
@@ -14,17 +14,16 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"github.com/couchbase/couchbase-exporter/pkg/collectors"
-	"github.com/couchbase/couchbase-exporter/pkg/util"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"github.com/couchbase/couchbase-exporter/pkg/collectors"
+	"github.com/couchbase/couchbase-exporter/pkg/log"
+	"github.com/couchbase/couchbase-exporter/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -32,8 +31,6 @@ const (
 	operatorPass = "COUCHBASE_OPERATOR_PASS"
 	bearerToken  = "AUTH_BEARER_TOKEN"
 )
-
-var log = logf.Log.WithName("metrics")
 
 var (
 	couchAddr   = flag.String("couchbase-address", "localhost", "The address where Couchbase Server is running")
@@ -50,13 +47,21 @@ var (
 	ca         = flag.String("ca", "", "PKI certificate authority file")
 	clientCert = flag.String("client-cert", "", "client certificate file to authenticate this client with couchbase-server")
 	clientKey  = flag.String("client-key", "", "client private key file to authenticate this client with couchbase-server")
+	logLevel   = flag.String("log-level", "warn", "log level (debug/info/warn/error)")
+	logJson    = flag.Bool("log-json", true, "if set to true, logs will be JSON formated")
 )
 
 func main() {
-	logf.SetLogger(zap.New())
-	log.Info("Starting metrics collection...")
-
 	flag.Parse()
+
+	if *logLevel != "" {
+		log.SetLevel(*logLevel)
+	}
+	if *logJson {
+		log.SetFormat("json")
+	}
+
+	log.Info("Starting metrics collection...")
 
 	validateInt(*svrPort, "server-port")
 	validateInt(*refreshTime, "per-node-refresh")
@@ -110,7 +115,7 @@ func serveMetrics() {
 
 	if len(*cert) == 0 && len(*key) == 0 {
 		if err := http.ListenAndServe(":"+*svrPort, &handler); err != nil {
-			log.Error(err, "failed to start server:")
+			log.Error("failed to start server: %v", err)
 		}
 	} else {
 		if len(*cert) != 0 && len(*key) != 0 {
@@ -118,12 +123,12 @@ func serveMetrics() {
 			log.Info("metrics server: " + metricsServer)
 
 			if err := http.ListenAndServeTLS(":"+*svrPort, *cert, *key, &handler); err != nil {
-				log.Error(err, "failed to start server:")
+				log.Error("failed to start server: %v", err)
 			}
 
 			log.Info("server started listening on", "server", metricsServer)
 		} else {
-			log.Error(fmt.Errorf("please specify both cert and key arguments"), "")
+			log.Error("please specify both cert and key arguments")
 			os.Exit(1)
 		}
 	}
@@ -191,7 +196,7 @@ func createClient(username, password string) util.Client {
 
 func validateInt(str, param string) {
 	if _, err := strconv.Atoi(str); err != nil {
-		log.Error(fmt.Errorf("%q is not a valid integer, parameter: %s.\n", str, param), "")
+		log.Error("%q is not a valid integer, parameter: %s.", str, param)
 		os.Exit(1)
 	}
 }

--- a/pkg/collectors/bucketinfo_collector.go
+++ b/pkg/collectors/bucketinfo_collector.go
@@ -10,10 +10,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 type bucketInfoCollector struct {
@@ -51,12 +52,12 @@ func (c *bucketInfoCollector) Collect(ch chan<- prometheus.Metric) {
 	buckets, err := c.m.client.Buckets()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape buckets")
+		log.Error("failed to scrape buckets")
 		return
 	}
 
 	for _, bucket := range buckets {
-		log.Debugf("Collecting %s bucket metrics...", bucket.Name)
+		log.Debug("Collecting %s bucket metrics...", bucket.Name)
 
 		ch <- prometheus.MustNewConstMetric(c.basicstatsDataused, prometheus.GaugeValue, bucket.BucketBasicStats.DataUsed, bucket.Name)
 		ch <- prometheus.MustNewConstMetric(c.basicstatsDiskfetches, prometheus.GaugeValue, bucket.BucketBasicStats.DiskFetches, bucket.Name)

--- a/pkg/collectors/bucketstats_collector.go
+++ b/pkg/collectors/bucketstats_collector.go
@@ -12,10 +12,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 const FQ_NAMESPACE = "cb"
@@ -384,17 +385,17 @@ func (c *bucketStatsCollector) Collect(ch chan<- prometheus.Metric) {
 	buckets, err := c.m.client.Buckets()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape buckets")
+		log.Error("failed to scrape buckets")
 		return
 	}
 
 	// nolint: lll
 	for _, bucket := range buckets {
-		log.Debugf("Collecting %s bucket stats metrics...", bucket.Name)
+		log.Debug("Collecting %s bucket stats metrics...", bucket.Name)
 		stats, err := c.m.client.BucketStats(bucket.Name)
 		if err != nil {
 			ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-			log.With("error", err).Error("failed to scrape bucket stats")
+			log.Error("failed to scrape bucket stats")
 			return
 		}
 

--- a/pkg/collectors/cbas_collector.go
+++ b/pkg/collectors/cbas_collector.go
@@ -10,10 +10,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 type cbasCollector struct {
@@ -123,7 +124,7 @@ func (c *cbasCollector) Collect(ch chan<- prometheus.Metric) {
 	cbas, err := c.m.client.Cbas()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape Analytics stats")
+		log.Error("failed to scrape Analytics stats")
 		return
 	}
 

--- a/pkg/collectors/eventing_collector.go
+++ b/pkg/collectors/eventing_collector.go
@@ -10,10 +10,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 type eventingCollector struct {
@@ -236,7 +237,7 @@ func (c *eventingCollector) Collect(ch chan<- prometheus.Metric) {
 	ev, err := c.m.client.Eventing()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape eventing stats")
+		log.Error("failed to scrape eventing stats")
 		return
 	}
 

--- a/pkg/collectors/index_collector.go
+++ b/pkg/collectors/index_collector.go
@@ -10,10 +10,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 type indexCollector struct {
@@ -91,7 +92,7 @@ func (c *indexCollector) Collect(ch chan<- prometheus.Metric) {
 	indexStats, err := c.m.client.Index()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape index stats")
+		log.Error("failed to scrape index stats")
 		return
 	}
 

--- a/pkg/collectors/node_collector.go
+++ b/pkg/collectors/node_collector.go
@@ -12,11 +12,12 @@
 package collectors
 
 import (
-	"github.com/couchbase/couchbase-exporter/pkg/util"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"strconv"
 	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
+	"github.com/couchbase/couchbase-exporter/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type nodesCollector struct {
@@ -385,13 +386,13 @@ func (c *nodesCollector) Collect(ch chan<- prometheus.Metric) {
 	nodes, err := c.m.client.Nodes()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape nodes")
+		log.Error("failed to scrape nodes")
 		return
 	}
 
 	// nolint: lll
 	for _, node := range nodes.Nodes {
-		log.Debugf("Collecting %s node metrics...", node.Hostname)
+		log.Debug("Collecting %s node metrics...", node.Hostname)
 		ch <- prometheus.MustNewConstMetric(c.healthy, prometheus.GaugeValue, boolToFloat64(node.Status == "healthy"), node.Hostname)
 		ch <- prometheus.MustNewConstMetric(c.interestingStatsCouchDocsActualDiskSize, prometheus.GaugeValue, node.InterestingStats.CouchDocsActualDiskSize, node.Hostname)
 		ch <- prometheus.MustNewConstMetric(c.interestingStatsCouchDocsDataSize, prometheus.GaugeValue, node.InterestingStats.CouchDocsDataSize, node.Hostname)

--- a/pkg/collectors/pernode_bucketstats.go
+++ b/pkg/collectors/pernode_bucketstats.go
@@ -13,15 +13,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/couchbase/couchbase-exporter/pkg/objects"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"net/http"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var (

--- a/pkg/collectors/query_collector.go
+++ b/pkg/collectors/query_collector.go
@@ -10,10 +10,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 type queryCollector struct {
@@ -211,7 +212,7 @@ func (c *queryCollector) Collect(ch chan<- prometheus.Metric) {
 	queryStats, err := c.m.client.Query()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape query stats")
+		log.Error("failed to scrape query stats")
 		return
 	}
 

--- a/pkg/collectors/search_collector.go
+++ b/pkg/collectors/search_collector.go
@@ -10,10 +10,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 type ftsCollector struct {
@@ -83,7 +84,7 @@ func (c *ftsCollector) Collect(ch chan<- prometheus.Metric) {
 	ftsStats, err := c.m.client.Fts()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape FTS stats")
+		log.Error("failed to scrape FTS stats")
 		return
 	}
 

--- a/pkg/collectors/task_collector.go
+++ b/pkg/collectors/task_collector.go
@@ -12,10 +12,11 @@
 package collectors
 
 import (
+	"time"
+
+	"github.com/couchbase/couchbase-exporter/pkg/log"
 	"github.com/couchbase/couchbase-exporter/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
-	"time"
 )
 
 type taskCollector struct {
@@ -161,13 +162,13 @@ func (c *taskCollector) Collect(ch chan<- prometheus.Metric) {
 	tasks, err := c.m.client.Tasks()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape tasks")
+		log.Error("failed to scrape tasks")
 		return
 	}
 	buckets, err := c.m.client.Buckets()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(c.m.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape tasks")
+		log.Error("failed to scrape tasks")
 		return
 	}
 
@@ -188,7 +189,7 @@ func (c *taskCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			compactsReported[task.Bucket] = true
 		case "xdcr":
-			log.Debugf("found xdcr tasks from %s to %s", task.Source, task.Target)
+			log.Debug("found xdcr tasks from %s to %s", task.Source, task.Target)
 			ch <- prometheus.MustNewConstMetric(c.xdcrChangesLeft, prometheus.GaugeValue, float64(task.ChangesLeft), task.Source, task.Target)
 			ch <- prometheus.MustNewConstMetric(c.xdcrDocsChecked, prometheus.GaugeValue, float64(task.DocsChecked), task.Source, task.Target)
 			ch <- prometheus.MustNewConstMetric(c.xdcrDocsWritten, prometheus.GaugeValue, float64(task.DocsWritten), task.Source, task.Target)
@@ -197,7 +198,7 @@ func (c *taskCollector) Collect(ch chan<- prometheus.Metric) {
 		case "clusterLogsCollection":
 			ch <- prometheus.MustNewConstMetric(c.clusterLogsCollection, prometheus.GaugeValue, task.Progress)
 		default:
-			log.With("type", task.Type).Warn("not implemented")
+			log.Warn("not implemented")
 		}
 	}
 	// always report the compacting task, even if it is not happening

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,111 @@
+package log
+
+import (
+	gofmt "fmt"
+	"os"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+var (
+	timestampFormat = log.TimestampFormat(
+		func() time.Time { return time.Now().UTC() },
+		"2006-01-02T15:04:05.000Z07:00",
+	)
+	defaultLogger = New(&Config{})
+)
+
+type logger struct {
+	debug log.Logger
+	info  log.Logger
+	warn  log.Logger
+	err   log.Logger
+
+	lvl    string
+	format string
+}
+
+func (l *logger) Debug(fmt string, v ...interface{}) error {
+	return l.debug.Log(prepareLog(fmt, v...))
+}
+
+func (l *logger) Info(fmt string, v ...interface{}) error {
+	return l.info.Log(prepareLog(fmt, v...))
+}
+
+func (l *logger) Warn(fmt string, v ...interface{}) error {
+	return l.warn.Log(prepareLog(fmt, v...))
+}
+
+func (l *logger) Error(fmt string, v ...interface{}) error {
+	return l.err.Log(prepareLog(fmt, v...))
+}
+
+func (l *logger) SetLevel(lvl string) {
+	*l = *(New(&Config{Level: lvl, Format: l.format}))
+}
+
+func (l *logger) SetFormat(format string) {
+	*l = *(New(&Config{Level: l.lvl, Format: format}))
+}
+
+func Debug(fmt string, v ...interface{}) error {
+	return defaultLogger.Debug(fmt, v...)
+}
+
+func Info(fmt string, v ...interface{}) error {
+	return defaultLogger.Info(fmt, v...)
+}
+
+func Warn(fmt string, v ...interface{}) error {
+	return defaultLogger.Warn(fmt, v...)
+}
+
+func Error(fmt string, v ...interface{}) error {
+	return defaultLogger.Error(fmt, v...)
+}
+
+func SetLevel(lvl string) {
+	*defaultLogger = *(New(&Config{Level: lvl, Format: defaultLogger.format}))
+}
+
+func SetFormat(format string) {
+	*defaultLogger = *(New(&Config{Level: defaultLogger.lvl, Format: format}))
+}
+
+type Config struct {
+	Level  string
+	Format string
+}
+
+func New(cfg *Config) *logger {
+	var l log.Logger
+	if cfg.Format == "json" {
+		l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+	} else {
+		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	}
+	l = log.With(level.NewFilter(l, parseLevel(cfg.Level)), "date", timestampFormat, "caller", log.DefaultCaller)
+	return &logger{debug: level.Debug(l), info: level.Info(l), warn: level.Warn(l), err: level.Error(l), lvl: cfg.Level, format: cfg.Format}
+}
+
+func prepareLog(fmt string, v ...interface{}) (string, string) {
+	return "message", gofmt.Sprintf(fmt, v...)
+}
+
+func parseLevel(l string) level.Option {
+	lvl := level.AllowWarn()
+	switch l {
+	case "debug":
+		lvl = level.AllowDebug()
+	case "info":
+		lvl = level.AllowInfo()
+	case "warn", "warning":
+		lvl = level.AllowWarn()
+	case "error", "err":
+		lvl = level.AllowError()
+	}
+	return lvl
+}


### PR DESCRIPTION
### Resolve deprecation

[Old log implementation](https://github.com/prometheus/common/tree/master/log) is **DEPRECATED** as explained [here](https://github.com/prometheus/common/README.md#deprecated).

### Improvements:
* Uniformize the way the exporter handle logs.
* Add level and format as configurable options.